### PR TITLE
Rename username_template to bind_dn_template

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ the LDAP Authenticator can be used:
 Address of the LDAP Server to contact. Just use a bare hostname or IP,
 without a port name or protocol prefix.
 
-#### `LDAPAuthenticator.username_template` ####
+#### `LDAPAuthenticator.bind_dn_template` ####
 
 Template to use to generate the full dn for a user from the human readable
 username. For example, if users in your LDAP database have DN of the form

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -27,10 +27,11 @@ class LDAPAuthenticator(Authenticator):
         config=True,
         help='Use SSL to encrypt connection to LDAP server'
     )
-    username_template = Unicode(
+
+    bind_dn_template = Unicode(
         config=True,
         help="""
-        Template from which to construct the full username
+        Template from which to construct the full dn
         when authenticating to LDAP. {username} is replaced
         with the actual username.
 
@@ -78,7 +79,7 @@ class LDAPAuthenticator(Authenticator):
             self.log.warn('Empty password')
             return None
 
-        userdn = self.username_template.format(username=username)
+        userdn = self.bind_dn_template.format(username=username)
 
         server = ldap3.Server(
             self.server_address,


### PR DESCRIPTION
More consistent with how it is used in other LDAP authenticators
for other software

Fixes #4