### PR TITLE
Changed allowed_groups traitlets type

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The `{username}` is expanded into the username the user provides.
 #### `LDAPAuthenticator.allowed_groups` ####
 
 LDAP groups whose members are allowed to log in. This must be
-set to either `False` (the default, to disable) or to a list of
+set to either empty `[]` (the default, to disable) or to a list of
 full DNs that have a `member` attribute that includes the current
 user attempting to log in.
 

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -41,17 +41,11 @@ class LDAPAuthenticator(Authenticator):
         """
     )
 
-    allowed_groups = Union([
-        Bool(
-            False,
-            config=True,
-            help="Set to false to disable group based access"
-            ),
-        List(
-            config=True,
-            help="List of LDAP Group DNs whose members are allowed access"
-        )
-    ])
+
+    allowed_groups = List(
+	config=True,
+	help="List of LDAP Group DNs whose members are allowed access"
+    )
 
     valid_username_regex = Unicode(
         r'^[a-z][.a-z0-9_-]*$',
@@ -89,7 +83,7 @@ class LDAPAuthenticator(Authenticator):
         conn = ldap3.Connection(server, user=userdn, password=password)
 
         if conn.bind():
-            if self.allowed_groups is not False:
+            if self.allowed_groups:
                 for group in self.allowed_groups:
                     if conn.search(
                         group,


### PR DESCRIPTION
`allowed_groups = Union([...])` did not work with Jupyterhub version 0.5.0, returning the error "Config option _allowed_groups_ not recognized by _LDAPAuthenticator_."

So I've changed it to use `List` instead, allowing it to be properly recognized in `jupyterhub_config.py`

If the list is empty it will allow all users to log in. Once the list is populated it will only allow users of that group to log in. 

Small readme change to reflect this. It's still an optional config, as the `List` default value is empty.